### PR TITLE
Fix patch attribute bug

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -7,7 +7,7 @@ function setAttribute(node, name, value) {
 }
 
 function removeAttribute(node, name) {
-  if (name === 'className') node.remove('class');
+  if (name === 'className') node.removeAttribute('class');
   else if (name === '__html') node.innerHTML = '';
   else node.removeAttribute(name);
 }


### PR DESCRIPTION
This PR fixes a bug to correctly remove the `class` attribute during the vdom patching process.